### PR TITLE
Add tests for calculate_leave_days

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -123,7 +123,14 @@ server {
 }
 ```
 
-### 6. Default Administrative Access
+### 6. Running Tests
+
+Run the unit tests using `pytest`:
+```bash
+pytest
+```
+
+### 7. Default Administrative Access
 
 When you first set up the application, a default admin account is created:
 - Username: admin

--- a/dependencies.txt
+++ b/dependencies.txt
@@ -11,3 +11,5 @@ pandas==2.1.1
 openpyxl==3.1.2
 sendgrid==6.10.0
 python-dotenv==1.0.0
+pytest==8.2.2
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,4 +16,5 @@ dependencies = [
     "openpyxl>=3.1.5",
     "pandas>=2.2.3",
     "sendgrid>=6.12.2",
+    "pytest>=8.2.2",
 ]

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,20 @@
+import datetime
+from utils.helpers import calculate_leave_days
+
+
+def test_calculate_leave_days_exclude_weekends():
+    start = datetime.date(2024, 1, 1)  # Monday
+    end = datetime.date(2024, 1, 7)    # Sunday
+    assert calculate_leave_days(start, end, include_weekends=False) == 5
+
+
+def test_calculate_leave_days_include_weekends():
+    start = datetime.date(2024, 1, 1)  # Monday
+    end = datetime.date(2024, 1, 7)    # Sunday
+    assert calculate_leave_days(start, end, include_weekends=True) == 7
+
+
+def test_calculate_leave_days_invalid_range():
+    start = datetime.date(2024, 1, 7)
+    end = datetime.date(2024, 1, 1)
+    assert calculate_leave_days(start, end) == 0


### PR DESCRIPTION
## Summary
- add unit tests covering calculate_leave_days
- include pytest in dependencies and update pyproject
- document running tests in README

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*