### PR TITLE
Unify pay period management

### DIFF
--- a/routes/admin.py
+++ b/routes/admin.py
@@ -2,7 +2,7 @@ from flask import Blueprint, render_template, request, redirect, url_for, flash,
 from flask_login import login_required, current_user
 from sqlalchemy.exc import SQLAlchemyError
 from app import db
-from models import User, Role, Department, Employee
+from models import User, Role, Department, Employee, PayPeriod, PayrollPeriod
 from utils.helpers import role_required
 
 admin_bp = Blueprint('admin', __name__, url_prefix='/admin')
@@ -396,4 +396,18 @@ def bulk_update_template():
         as_attachment=True,
         download_name=filename,
         mimetype=mimetype
+    )
+
+
+@admin_bp.route('/pay-periods')
+@login_required
+@role_required('Admin', 'HR')
+def manage_pay_periods():
+    """Unified management view for timesheet and payroll pay periods"""
+    timesheet_periods = PayPeriod.query.order_by(PayPeriod.start_date.desc()).all()
+    payroll_periods = PayrollPeriod.query.order_by(PayrollPeriod.start_date.desc()).all()
+    return render_template(
+        'admin/pay_periods.html',
+        timesheet_periods=timesheet_periods,
+        payroll_periods=payroll_periods
     )

--- a/templates/admin/pay_periods.html
+++ b/templates/admin/pay_periods.html
@@ -1,0 +1,85 @@
+{% extends "layout.html" %}
+
+{% block title %}Manage Pay Periods{% endblock %}
+
+{% block content %}
+<div class="container-fluid">
+    <h1 class="h3 mb-4">Manage Pay Periods</h1>
+    <div class="row">
+        <div class="col-lg-6">
+            <div class="card shadow mb-4">
+                <div class="card-header py-3 d-flex justify-content-between align-items-center">
+                    <h6 class="m-0 fw-bold">Timesheet Pay Periods</h6>
+                    <a href="{{ url_for('timesheets.pay_periods') }}" class="btn btn-sm btn-secondary">Full View</a>
+                </div>
+                <div class="card-body">
+                    {% if timesheet_periods %}
+                    <div class="table-responsive">
+                        <table class="table table-bordered">
+                            <thead>
+                                <tr>
+                                    <th>ID</th>
+                                    <th>Start</th>
+                                    <th>End</th>
+                                    <th>Status</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for period in timesheet_periods %}
+                                <tr>
+                                    <td>{{ period.id }}</td>
+                                    <td>{{ period.start_date.strftime('%Y-%m-%d') }}</td>
+                                    <td>{{ period.end_date.strftime('%Y-%m-%d') }}</td>
+                                    <td>{{ period.status }}</td>
+                                </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                    {% else %}
+                    <p>No timesheet pay periods found.</p>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+        <div class="col-lg-6">
+            <div class="card shadow mb-4">
+                <div class="card-header py-3 d-flex justify-content-between align-items-center">
+                    <h6 class="m-0 fw-bold">Payroll Periods</h6>
+                    <a href="{{ url_for('payroll.payroll_periods') }}" class="btn btn-sm btn-secondary">Full View</a>
+                </div>
+                <div class="card-body">
+                    {% if payroll_periods %}
+                    <div class="table-responsive">
+                        <table class="table table-bordered">
+                            <thead>
+                                <tr>
+                                    <th>ID</th>
+                                    <th>Start</th>
+                                    <th>End</th>
+                                    <th>Pay Date</th>
+                                    <th>Status</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for period in payroll_periods %}
+                                <tr>
+                                    <td>{{ period.id }}</td>
+                                    <td>{{ period.start_date.strftime('%Y-%m-%d') }}</td>
+                                    <td>{{ period.end_date.strftime('%Y-%m-%d') }}</td>
+                                    <td>{{ period.payment_date.strftime('%Y-%m-%d') }}</td>
+                                    <td>{{ period.status }}</td>
+                                </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                    {% else %}
+                    <p>No payroll periods found.</p>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -224,7 +224,15 @@
                         </ul>
                     </li>
                     {% endif %}
-                    
+
+                    {% if current_user.role.name in ['Admin', 'HR'] %}
+                    <li class="nav-item">
+                        <a class="nav-link" href="{{ url_for('admin.manage_pay_periods') }}">
+                            <i class="fas fa-calendar-alt"></i> Manage Pay Periods
+                        </a>
+                    </li>
+                    {% endif %}
+
                     {% if current_user.role.name == 'Admin' %}
                     <li class="nav-item">
                         <a class="nav-link" href="{{ url_for('admin.settings') }}">

--- a/templates/payroll/index.html
+++ b/templates/payroll/index.html
@@ -9,7 +9,7 @@
         <h1 class="h3 mb-0 text-light">Payroll Dashboard</h1>
         {% if current_user.has_role(['Admin', 'HR']) %}
         <div>
-            <a href="{{ url_for('payroll.payroll_periods') }}" class="btn btn-primary">
+            <a href="{{ url_for('admin.manage_pay_periods') }}" class="btn btn-primary">
                 <i class="fas fa-calendar-alt me-1"></i> Manage Pay Periods
             </a>
             <a href="{{ url_for('payroll.payslips') }}" class="btn btn-info ms-2">

--- a/templates/timesheets/admin_view.html
+++ b/templates/timesheets/admin_view.html
@@ -14,7 +14,7 @@
                 <i class="fas fa-user-clock me-2"></i> Go to My Timesheet
             </a>
             {% endif %}
-            <a href="{{ url_for('timesheets.pay_periods') }}" class="btn btn-primary">
+            <a href="{{ url_for('admin.manage_pay_periods') }}" class="btn btn-primary">
                 <i class="fas fa-calendar-alt"></i> Manage Pay Periods
             </a>
         </div>


### PR DESCRIPTION
## Summary
- centralize pay period management in `admin.manage_pay_periods`
- display both timesheet and payroll periods on a new admin page
- update navigation to link to the new page
- move manage pay period buttons to use the unified admin location

## Testing
- `pytest -q` *(fails: command not found)*