### PR TITLE
Add permission-based role management

### DIFF
--- a/routes/admin.py
+++ b/routes/admin.py
@@ -2,7 +2,7 @@ from flask import Blueprint, render_template, request, redirect, url_for, flash,
 from flask_login import login_required, current_user
 from sqlalchemy.exc import SQLAlchemyError
 from app import db
-from models import User, Role, Department, Employee, PayPeriod, PayrollPeriod
+from models import User, Role, Permission, Department, Employee, PayPeriod, PayrollPeriod
 from utils.helpers import role_required
 
 admin_bp = Blueprint('admin', __name__, url_prefix='/admin')
@@ -43,7 +43,8 @@ def user_management():
     """User management page."""
     users = User.query.all()
     roles = Role.query.all()
-    return render_template('admin/users.html', users=users, roles=roles)
+    all_permissions = Permission.query.all()
+    return render_template('admin/users.html', users=users, roles=roles, all_permissions=all_permissions)
 
 @admin_bp.route('/users/edit/<int:user_id>', methods=['GET', 'POST'])
 @login_required
@@ -127,11 +128,12 @@ def create_role():
     new_role = Role()
     new_role.name = name
     new_role.description = description
-    
-    # Store permissions as comma-separated string in description field for now
-    # In a real application, you would use a separate permissions table
-    if permissions:
-        new_role.description = f"{description}\nPermissions: {', '.join(permissions)}"
+
+    # Attach permissions
+    for perm_name in permissions:
+        perm = Permission.query.filter_by(name=perm_name).first()
+        if perm:
+            new_role.permissions.append(perm)
     
     db.session.add(new_role)
     db.session.commit()
@@ -154,34 +156,35 @@ def edit_role(role_id):
         # Validate data
         if not name:
             flash('Role name is required.', 'danger')
-            return render_template('admin/edit_role.html', role=role)
+            all_permissions = Permission.query.all()
+            return render_template('admin/edit_role.html', role=role, permissions=permissions, all_permissions=all_permissions)
         
         # Check if name already exists for another role
         existing_role = Role.query.filter(Role.name == name, Role.id != role_id).first()
         if existing_role:
             flash('Role name already exists.', 'danger')
-            return render_template('admin/edit_role.html', role=role)
+            all_permissions = Permission.query.all()
+            return render_template('admin/edit_role.html', role=role, permissions=permissions, all_permissions=all_permissions)
         
         # Update role
         role.name = name
         role.description = description
-        
-        # Store permissions as comma-separated string in description field for now
-        if permissions:
-            role.description = f"{description}\nPermissions: {', '.join(permissions)}"
+
+        # Update permissions
+        role.permissions.clear()
+        for perm_name in permissions:
+            perm = Permission.query.filter_by(name=perm_name).first()
+            if perm:
+                role.permissions.append(perm)
         
         db.session.commit()
         flash('Role updated successfully.', 'success')
         return redirect(url_for('admin.user_management'))
     
-    # Extract permissions from description if they exist
-    permissions = []
-    if role.description and 'Permissions:' in role.description:
-        parts = role.description.split('Permissions:')
-        if len(parts) > 1:
-            permissions = [p.strip() for p in parts[1].split(',')]
-    
-    return render_template('admin/edit_role.html', role=role, permissions=permissions)
+    # Get current permission names
+    permissions = [p.name for p in role.permissions]
+    all_permissions = Permission.query.all()
+    return render_template('admin/edit_role.html', role=role, permissions=permissions, all_permissions=all_permissions)
 
 @admin_bp.route('/departments', methods=['GET'])
 @login_required

--- a/seed_data.py
+++ b/seed_data.py
@@ -1,6 +1,6 @@
 from datetime import date
 from app import app, db
-from models import User, Role, Department, Employee, DocumentType, LeaveType
+from models import User, Role, Permission, Department, Employee, DocumentType, LeaveType
 
 def create_document_types():
     """Create standard document types"""
@@ -39,6 +39,25 @@ def create_document_types():
     db.session.commit()
     print("Document types created successfully.")
 
+
+def create_permissions():
+    """Create standard permissions"""
+    perms = [
+        ("employee_view", "View Employees"),
+        ("employee_edit", "Edit Employees"),
+        ("attendance_manage", "Manage Attendance"),
+        ("leave_approve", "Approve Leave Requests"),
+        ("document_manage", "Manage Documents"),
+        ("user_manage", "Manage Users"),
+        ("system_admin", "System Administration"),
+    ]
+
+    for name, desc in perms:
+        if not Permission.query.filter_by(name=name).first():
+            db.session.add(Permission(name=name, description=desc))
+    db.session.commit()
+    print("Permissions created successfully.")
+
 def create_seed_data():
     """Creates initial seed data for the application"""
     with app.app_context():
@@ -58,6 +77,9 @@ def create_seed_data():
             return
         
         print("Creating seed data...")
+
+        # Create base permissions
+        create_permissions()
         
         # Create roles
         admin_role = Role(name="Admin", description="Administrator with full access")
@@ -66,6 +88,24 @@ def create_seed_data():
         employee_role = Role(name="Employee", description="Regular employee")
         
         db.session.add_all([admin_role, hr_role, manager_role, employee_role])
+        db.session.commit()
+
+        # Assign permissions to roles
+        perms = {p.name: p for p in Permission.query.all()}
+        admin_role.permissions.extend(perms.values())
+        hr_role.permissions.extend([p for p in [
+            perms.get('employee_view'),
+            perms.get('employee_edit'),
+            perms.get('attendance_manage'),
+            perms.get('leave_approve'),
+            perms.get('document_manage'),
+            perms.get('user_manage'),
+        ] if p])
+        manager_role.permissions.extend([p for p in [
+            perms.get('employee_view'),
+            perms.get('attendance_manage'),
+            perms.get('leave_approve'),
+        ] if p])
         db.session.commit()
         
         # Create departments

--- a/templates/admin/edit_role.html
+++ b/templates/admin/edit_role.html
@@ -32,46 +32,18 @@
                         
                         <div class="mb-3">
                             <label for="description" class="form-label">Description</label>
-                            <textarea class="form-control" id="description" name="description" rows="3">{{ role.description.split('\nPermissions:')[0] if role.description and '\nPermissions:' in role.description else role.description }}</textarea>
+                            <textarea class="form-control" id="description" name="description" rows="3">{{ role.description }}</textarea>
                         </div>
                         
                         <div class="mb-3">
                             <label class="form-label">Permissions</label>
+                            {% for perm in all_permissions %}
                             <div class="form-check">
-                                <input class="form-check-input" type="checkbox" id="perm_employee_view" name="permissions[]" value="employee_view" 
-                                {% if permissions and 'employee_view' in permissions %}checked{% endif %}>
-                                <label class="form-check-label" for="perm_employee_view">View Employees</label>
+                                <input class="form-check-input" type="checkbox" id="perm_{{ perm.name }}" name="permissions[]" value="{{ perm.name }}"
+                                {% if permissions and perm.name in permissions %}checked{% endif %}>
+                                <label class="form-check-label" for="perm_{{ perm.name }}">{{ perm.description or perm.name }}</label>
                             </div>
-                            <div class="form-check">
-                                <input class="form-check-input" type="checkbox" id="perm_employee_edit" name="permissions[]" value="employee_edit" 
-                                {% if permissions and 'employee_edit' in permissions %}checked{% endif %}>
-                                <label class="form-check-label" for="perm_employee_edit">Edit Employees</label>
-                            </div>
-                            <div class="form-check">
-                                <input class="form-check-input" type="checkbox" id="perm_attendance_manage" name="permissions[]" value="attendance_manage" 
-                                {% if permissions and 'attendance_manage' in permissions %}checked{% endif %}>
-                                <label class="form-check-label" for="perm_attendance_manage">Manage Attendance</label>
-                            </div>
-                            <div class="form-check">
-                                <input class="form-check-input" type="checkbox" id="perm_leave_approve" name="permissions[]" value="leave_approve" 
-                                {% if permissions and 'leave_approve' in permissions %}checked{% endif %}>
-                                <label class="form-check-label" for="perm_leave_approve">Approve Leave Requests</label>
-                            </div>
-                            <div class="form-check">
-                                <input class="form-check-input" type="checkbox" id="perm_document_manage" name="permissions[]" value="document_manage" 
-                                {% if permissions and 'document_manage' in permissions %}checked{% endif %}>
-                                <label class="form-check-label" for="perm_document_manage">Manage Documents</label>
-                            </div>
-                            <div class="form-check">
-                                <input class="form-check-input" type="checkbox" id="perm_user_manage" name="permissions[]" value="user_manage" 
-                                {% if permissions and 'user_manage' in permissions %}checked{% endif %}>
-                                <label class="form-check-label" for="perm_user_manage">Manage Users</label>
-                            </div>
-                            <div class="form-check">
-                                <input class="form-check-input" type="checkbox" id="perm_system_admin" name="permissions[]" value="system_admin" 
-                                {% if permissions and 'system_admin' in permissions %}checked{% endif %}>
-                                <label class="form-check-label" for="perm_system_admin">System Administration</label>
-                            </div>
+                            {% endfor %}
                         </div>
                         
                         <!-- Role Users Information -->

--- a/templates/admin/users.html
+++ b/templates/admin/users.html
@@ -194,34 +194,12 @@
                     
                     <div class="mb-3">
                         <label class="form-label">Permissions</label>
+                        {% for perm in all_permissions %}
                         <div class="form-check">
-                            <input class="form-check-input" type="checkbox" id="perm_employee_view" name="permissions[]" value="employee_view">
-                            <label class="form-check-label" for="perm_employee_view">View Employees</label>
+                            <input class="form-check-input" type="checkbox" id="perm_{{ perm.name }}" name="permissions[]" value="{{ perm.name }}">
+                            <label class="form-check-label" for="perm_{{ perm.name }}">{{ perm.description or perm.name }}</label>
                         </div>
-                        <div class="form-check">
-                            <input class="form-check-input" type="checkbox" id="perm_employee_edit" name="permissions[]" value="employee_edit">
-                            <label class="form-check-label" for="perm_employee_edit">Edit Employees</label>
-                        </div>
-                        <div class="form-check">
-                            <input class="form-check-input" type="checkbox" id="perm_attendance_manage" name="permissions[]" value="attendance_manage">
-                            <label class="form-check-label" for="perm_attendance_manage">Manage Attendance</label>
-                        </div>
-                        <div class="form-check">
-                            <input class="form-check-input" type="checkbox" id="perm_leave_approve" name="permissions[]" value="leave_approve">
-                            <label class="form-check-label" for="perm_leave_approve">Approve Leave Requests</label>
-                        </div>
-                        <div class="form-check">
-                            <input class="form-check-input" type="checkbox" id="perm_document_manage" name="permissions[]" value="document_manage">
-                            <label class="form-check-label" for="perm_document_manage">Manage Documents</label>
-                        </div>
-                        <div class="form-check">
-                            <input class="form-check-input" type="checkbox" id="perm_user_manage" name="permissions[]" value="user_manage">
-                            <label class="form-check-label" for="perm_user_manage">Manage Users</label>
-                        </div>
-                        <div class="form-check">
-                            <input class="form-check-input" type="checkbox" id="perm_system_admin" name="permissions[]" value="system_admin">
-                            <label class="form-check-label" for="perm_system_admin">System Administration</label>
-                        </div>
+                        {% endfor %}
                     </div>
                 </form>
             </div>

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -56,6 +56,25 @@ def role_required(*roles):
         return decorated_function
     return decorator
 
+
+def permission_required(permission):
+    """Decorator to check if the current user's role has a permission."""
+
+    def decorator(f):
+        @wraps(f)
+        def decorated_function(*args, **kwargs):
+            if not current_user.is_authenticated:
+                return redirect(url_for('auth.login'))
+
+            if not current_user.has_permission(permission):
+                flash('You do not have permission to access this page.', 'danger')
+                abort(403)
+            return f(*args, **kwargs)
+
+        return decorated_function
+
+    return decorator
+
 def calculate_leave_days(start_date, end_date, include_weekends=False):
     """Calculate the number of leave days between two dates"""
     if start_date > end_date:


### PR DESCRIPTION
## Summary
- implement `Permission` model and `role_permissions` table
- add `permission_required` decorator
- update admin routes and templates to manage role permissions
- seed default permissions and assign to roles

## Testing
- `pytest -q` *(fails: pytest not installed)*