### PR TITLE
Fix payroll date formatting error

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,7 +5,7 @@ from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy.orm import DeclarativeBase
 from werkzeug.middleware.proxy_fix import ProxyFix
 from flask_login import LoginManager
-from utils.filters import format_currency
+from utils.filters import format_currency, format_date
 
 
 class Base(DeclarativeBase):
@@ -37,6 +37,7 @@ login_manager.login_message_category = 'info'
 
 # Register custom Jinja2 filters
 app.jinja_env.filters['format_currency'] = format_currency
+app.jinja_env.filters['format_date'] = format_date
 
 # Import and register blueprints
 from routes.auth import auth_bp

--- a/templates/payroll/index.html
+++ b/templates/payroll/index.html
@@ -34,10 +34,10 @@
                                 <div class="mb-3">
                                     <h5>Period Details</h5>
                                     <div class="mb-2">
-                                        <strong>Dates:</strong> {{ current_period.start_date.strftime('%b %d, %Y') }} - {{ current_period.end_date.strftime('%b %d, %Y') }}
-                                    </div>
-                                    <div class="mb-2">
-                                        <strong>Payment Date:</strong> {{ current_period.payment_date.strftime('%b %d, %Y') }}
+                                         <strong>Dates:</strong> {{ current_period.start_date|format_date }} - {{ current_period.end_date|format_date }}
+                                      </div>
+                                      <div class="mb-2">
+                                          <strong>Payment Date:</strong> {{ current_period.payment_date|format_date }}
                                     </div>
                                     <div class="mb-2">
                                         <strong>Status:</strong> 
@@ -136,8 +136,8 @@
                             <tbody>
                                 {% for period in upcoming_periods %}
                                 <tr>
-                                    <td>{{ period.start_date.strftime('%b %d') }} - {{ period.end_date.strftime('%b %d, %Y') }}</td>
-                                    <td>{{ period.payment_date.strftime('%b %d, %Y') }}</td>
+                                    <td>{{ period.start_date|format_date('%b %d') }} - {{ period.end_date|format_date }}</td>
+                                    <td>{{ period.payment_date|format_date }}</td>
                                     <td>
                                         <span class="badge bg-{{ 'success' if period.status == 'Completed' else 'warning' if period.status == 'Processing' else 'secondary' }}">
                                             {{ period.status }}
@@ -179,8 +179,8 @@
                             <tbody>
                                 {% for period in past_periods %}
                                 <tr>
-                                    <td>{{ period.start_date.strftime('%b %d') }} - {{ period.end_date.strftime('%b %d, %Y') }}</td>
-                                    <td>{{ period.payment_date.strftime('%b %d, %Y') }}</td>
+                                    <td>{{ period.start_date|format_date('%b %d') }} - {{ period.end_date|format_date }}</td>
+                                    <td>{{ period.payment_date|format_date }}</td>
                                     <td>
                                         <span class="badge bg-{{ 'success' if period.status == 'Completed' else 'warning' if period.status == 'Processing' else 'secondary' }}">
                                             {{ period.status }}
@@ -268,8 +268,8 @@
                         {% for payslip in recent_payslips %}
                         <a href="{{ url_for('payroll.view_payslip', payroll_id=payslip.id) }}" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
                             <div>
-                                <div class="fw-bold">{{ payslip.pay_period.start_date.strftime('%b %d') }} - {{ payslip.pay_period.end_date.strftime('%b %d') }}</div>
-                                <div class="text-muted small">{{ payslip.pay_period.payment_date.strftime('%b %d, %Y') }}</div>
+                                <div class="fw-bold">{{ payslip.pay_period.start_date|format_date('%b %d') }} - {{ payslip.pay_period.end_date|format_date('%b %d') }}</div>
+                                <div class="text-muted small">{{ payslip.pay_period.payment_date|format_date }}</div>
                             </div>
                             <div class="text-end">
                                 <div class="fw-bold">{{ payslip.net_pay|format_currency if payslip.net_pay else '$0.00' }}</div>

--- a/templates/payroll/my_compensation.html
+++ b/templates/payroll/my_compensation.html
@@ -160,7 +160,7 @@
                                     <td><span class="badge bg-primary">Base Pay</span></td>
                                     <td>${{ "{:,.2f}".format(employee.base_salary) }}</td>
                                     <td>{{ employee.salary_type }}</td>
-                                    <td>{{ employee.start_date.strftime('%b %d, %Y') }}</td>
+                                    <td>{{ employee.start_date|format_date }}</td>
                                 </tr>
                                 
                                 {% for component in components %}
@@ -173,7 +173,7 @@
                                     </td>
                                     <td>${{ "{:,.2f}".format(component.amount) }}</td>
                                     <td>{{ component.frequency }}</td>
-                                    <td>{{ component.effective_date.strftime('%b %d, %Y') }}</td>
+                                    <td>{{ component.effective_date|format_date }}</td>
                                 </tr>
                                 {% endfor %}
                             </tbody>
@@ -216,7 +216,7 @@
                         </li>
                         <li class="list-group-item d-flex justify-content-between align-items-center bg-transparent">
                             <span>Start Date</span>
-                            <span class="fw-bold">{{ employee.start_date.strftime('%b %d, %Y') }}</span>
+                            <span class="fw-bold">{{ employee.start_date|format_date }}</span>
                         </li>
                         <li class="list-group-item d-flex justify-content-between align-items-center bg-transparent">
                             <span>Years of Service</span>
@@ -256,7 +256,7 @@
                             </div>
                             <div class="d-flex justify-content-between small">
                                 <span>Start Date:</span>
-                                <span>{{ emp_benefit.start_date.strftime('%b %d, %Y') }}</span>
+                                <span>{{ emp_benefit.start_date|format_date }}</span>
                             </div>
                         </li>
                         {% endfor %}
@@ -314,7 +314,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const payslips = [
         {% for payslip in payroll_history %}
         {
-            period: "{{ payslip.pay_period.start_date.strftime('%b %d') }} - {{ payslip.pay_period.end_date.strftime('%b %d') }}",
+            period: "{{ payslip.pay_period.start_date|format_date('%b %d') }} - {{ payslip.pay_period.end_date|format_date('%b %d') }}",
             gross: {{ payslip.gross_pay }},
             net: {{ payslip.net_pay }},
             tax: {{ payslip.tax_amount }}

--- a/templates/payroll/my_payslips.html
+++ b/templates/payroll/my_payslips.html
@@ -48,8 +48,8 @@
                             <tbody>
                                 {% for payslip in payslips %}
                                 <tr>
-                                    <td>{{ payslip.pay_period.start_date.strftime('%b %d') }} - {{ payslip.pay_period.end_date.strftime('%b %d, %Y') }}</td>
-                                    <td>{{ payslip.pay_period.payment_date.strftime('%b %d, %Y') }}</td>
+                                    <td>{{ payslip.pay_period.start_date|format_date('%b %d') }} - {{ payslip.pay_period.end_date|format_date }}</td>
+                                    <td>{{ payslip.pay_period.payment_date|format_date }}</td>
                                     <td>${{ "{:,.2f}".format(payslip.gross_pay) }}</td>
                                     <td>${{ "{:,.2f}".format(payslip.net_pay) }}</td>
                                     <td>
@@ -203,11 +203,11 @@
                     <div class="alert alert-info">
                         <div class="mb-2">
                             <strong>Period Dates:</strong><br>
-                            {{ current_period.start_date.strftime('%b %d, %Y') }} - {{ current_period.end_date.strftime('%b %d, %Y') }}
+                            {{ current_period.start_date|format_date }} - {{ current_period.end_date|format_date }}
                         </div>
                         <div class="mb-2">
                             <strong>Payment Date:</strong><br>
-                            {{ current_period.payment_date.strftime('%b %d, %Y') }}
+                            {{ current_period.payment_date|format_date }}
                         </div>
                         <div>
                             <strong>Status:</strong><br>

--- a/templates/payroll/periods.html
+++ b/templates/payroll/periods.html
@@ -40,12 +40,12 @@
                                 <tr {% if period.is_current %}class="table-primary"{% endif %}>
                                     <td>{{ period.id }}</td>
                                     <td>
-                                        {{ period.start_date.strftime('%b %d') }} - {{ period.end_date.strftime('%b %d, %Y') }}
+                                        {{ period.start_date|format_date('%b %d') }} - {{ period.end_date|format_date }}
                                         {% if period.is_current %}
                                             <span class="badge bg-info ms-2">Current</span>
                                         {% endif %}
                                     </td>
-                                    <td>{{ period.payment_date.strftime('%b %d, %Y') }}</td>
+                                    <td>{{ period.payment_date|format_date }}</td>
                                     <td>{{ period.total_days }} days</td>
                                     <td>
                                         <span class="badge bg-{{ 'success' if period.status == 'Completed' else 'warning' if period.status == 'Processing' else 'secondary' }}">

--- a/templates/payroll/view_payslip.html
+++ b/templates/payroll/view_payslip.html
@@ -49,8 +49,8 @@
                         </div>
                         <div class="col-sm-6 text-md-end">
                             <h5>Pay Period</h5>
-                            <p class="mb-1">{{ payslip.pay_period.start_date.strftime('%b %d') }} - {{ payslip.pay_period.end_date.strftime('%b %d, %Y') }}</p>
-                            <p class="mb-1">Payment Date: {{ payslip.pay_period.payment_date.strftime('%b %d, %Y') }}</p>
+                            <p class="mb-1">{{ payslip.pay_period.start_date|format_date('%b %d') }} - {{ payslip.pay_period.end_date|format_date }}</p>
+                            <p class="mb-1">Payment Date: {{ payslip.pay_period.payment_date|format_date }}</p>
                         </div>
                     </div>
                     
@@ -191,7 +191,7 @@
                 </div>
                 <div class="card-footer">
                     <div class="text-center text-muted">
-                        <small>Generated on {{ payslip.created_at.strftime('%b %d, %Y %H:%M') }}</small>
+                        <small>Generated on {{ payslip.created_at|format_date('%b %d, %Y %H:%M') }}</small>
                     </div>
                 </div>
             </div>

--- a/templates/payroll/view_period.html
+++ b/templates/payroll/view_period.html
@@ -47,7 +47,7 @@
                             <strong>Start Date:</strong>
                         </div>
                         <div class="col-md-7">
-                            {{ period.start_date.strftime('%b %d, %Y') }}
+                            {{ period.start_date|format_date }}
                         </div>
                     </div>
                     
@@ -56,7 +56,7 @@
                             <strong>End Date:</strong>
                         </div>
                         <div class="col-md-7">
-                            {{ period.end_date.strftime('%b %d, %Y') }}
+                            {{ period.end_date|format_date }}
                         </div>
                     </div>
                     
@@ -65,7 +65,7 @@
                             <strong>Payment Date:</strong>
                         </div>
                         <div class="col-md-7">
-                            {{ period.payment_date.strftime('%b %d, %Y') }}
+                            {{ period.payment_date|format_date }}
                         </div>
                     </div>
                     
@@ -83,7 +83,7 @@
                             <strong>Created:</strong>
                         </div>
                         <div class="col-md-7">
-                            {{ period.created_at.strftime('%b %d, %Y %H:%M') }}
+                            {{ period.created_at|format_date('%b %d, %Y %H:%M') }}
                         </div>
                     </div>
                 </div>

--- a/utils/filters.py
+++ b/utils/filters.py
@@ -1,7 +1,19 @@
 """Jinja2 filter functions for the application."""
 
-def format_currency(amount, currency='$'):
-    """Format a number as currency"""
+from datetime import datetime, date
+
+
+def format_currency(amount, currency: str = "$"):
+    """Format a number as currency for templates."""
     if amount is None:
         return f"{currency}0.00"
     return f"{currency}{amount:,.2f}"
+
+
+def format_date(value, fmt: str = "%b %d, %Y"):
+    """Safely format a date or datetime object for display."""
+    if value is None:
+        return ""
+    if isinstance(value, (datetime, date)):
+        return value.strftime(fmt)
+    return str(value)


### PR DESCRIPTION
## Summary
- add a `format_date` Jinja2 filter to safely handle `None` dates
- register the new filter in the Flask app
- use the new filter across payroll templates

## Testing
- `python -m py_compile utils/filters.py app.py`
- `pytest -q` *(fails: command not found)*