### PR TITLE
Add bulk pay period creation and update links

### DIFF
--- a/templates/payroll/index.html
+++ b/templates/payroll/index.html
@@ -106,7 +106,7 @@
                             
                             {% if current_user.has_role(['Admin', 'HR']) %}
                             <div class="mt-3">
-                                <a href="{{ url_for('payroll.create_period') }}" class="btn btn-primary">
+                                <a href="{{ url_for('timesheets.pay_periods') }}" class="btn btn-primary">
                                     <i class="fas fa-plus me-1"></i> Create Pay Period
                                 </a>
                             </div>
@@ -299,7 +299,7 @@
                 </div>
                 <div class="card-body">
                     <div class="d-grid gap-2">
-                        <a href="{{ url_for('payroll.create_period') }}" class="btn btn-primary">
+                        <a href="{{ url_for('timesheets.pay_periods') }}" class="btn btn-primary">
                             <i class="fas fa-plus me-2"></i> Create Pay Period
                         </a>
                         <a href="{{ url_for('payroll.payslips') }}?status=Pending" class="btn btn-warning">

--- a/templates/payroll/periods.html
+++ b/templates/payroll/periods.html
@@ -8,7 +8,7 @@
     <div class="d-flex justify-content-between align-items-center mb-4">
         <h1 class="h3 mb-0 text-light">Payroll Periods</h1>
         <div>
-            <a href="{{ url_for('payroll.create_period') }}" class="btn btn-primary">
+            <a href="{{ url_for('timesheets.pay_periods') }}" class="btn btn-primary">
                 <i class="fas fa-plus"></i> Create Period
             </a>
         </div>
@@ -85,7 +85,7 @@
                 <div class="alert alert-info">
                     <i class="fas fa-info-circle"></i> No payroll periods have been created yet.
                     <div class="mt-3">
-                        <a href="{{ url_for('payroll.create_period') }}" class="btn btn-primary">
+                        <a href="{{ url_for('timesheets.pay_periods') }}" class="btn btn-primary">
                             <i class="fas fa-plus"></i> Create First Pay Period
                         </a>
                     </div>

--- a/templates/timesheets/pay_periods.html
+++ b/templates/timesheets/pay_periods.html
@@ -41,6 +41,30 @@
                     </form>
                 </div>
             </div>
+
+            <!-- Bulk Create Pay Periods -->
+            <div class="card shadow mt-4">
+                <div class="card-header py-3">
+                    <h6 class="m-0 fw-bold">Bulk Create Pay Periods</h6>
+                </div>
+                <div class="card-body">
+                    <form method="post" action="{{ url_for('timesheets.create_pay_period_range') }}">
+                        <div class="mb-3">
+                            <label for="range_start_date" class="form-label">Start Date</label>
+                            <input type="date" class="form-control" id="range_start_date" name="start_date" required>
+                        </div>
+                        <div class="mb-3">
+                            <label for="period_count" class="form-label">Number of Periods</label>
+                            <input type="number" class="form-control" id="period_count" name="period_count" min="1" value="5" required>
+                        </div>
+                        <div class="d-grid">
+                            <button type="submit" class="btn btn-primary">
+                                <i class="fas fa-plus-circle"></i> Create Range
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
             
             <!-- Pay Period Guidelines -->
             <div class="card shadow mt-4">
@@ -159,6 +183,11 @@ document.addEventListener('DOMContentLoaded', function() {
         // Format dates for input elements
         document.getElementById('start_date').value = formatDateForInput(nextMonday);
         document.getElementById('end_date').value = formatDateForInput(endDate);
+
+        const bulkStart = document.getElementById('range_start_date');
+        if (bulkStart) {
+            bulkStart.value = formatDateForInput(nextMonday);
+        }
     }
     
     // Format date for input field (YYYY-MM-DD)


### PR DESCRIPTION
## Summary
- allow creating multiple pay periods at once via `/periods/create-range`
- expose bulk creation form on **Manage Pay Periods** page
- link Payroll pages to the management screen instead of their own creation view

## Testing
- `pytest -q` *(fails: `pytest` not found)*