### PR TITLE
Add employment type to employee UI

### DIFF
--- a/routes/employees.py
+++ b/routes/employees.py
@@ -179,7 +179,8 @@ def create_employee():
                 'status': request.form.get('status', 'Active'),
                 'is_manager': bool(request.form.get('is_manager')),  # Checkbox returns 'on' if checked or None if not
                 'level': request.form.get('level'),
-                'education_level': request.form.get('education_level')
+                'education_level': request.form.get('education_level'),
+                'employment_type': request.form.get('employment_type')
             }
             
             # Handle birth_date if provided
@@ -286,6 +287,7 @@ def edit_employee(id):
             employee.is_manager = bool(request.form.get('is_manager'))
             employee.level = request.form.get('level')
             employee.education_level = request.form.get('education_level')
+            employee.employment_type = request.form.get('employment_type')
             
             # Handle dates
             new_hire_date = request.form.get('hire_date')

--- a/templates/employees/edit.html
+++ b/templates/employees/edit.html
@@ -231,7 +231,7 @@
                     </div>
                     
                     <!-- Education Level -->
-                    <div class="col-md-8 mb-3">
+                    <div class="col-md-4 mb-3">
                         <label for="education_level" class="form-label">Education Level</label>
                         <select class="form-select" id="education_level" name="education_level">
                             <option value="" {% if not employee or not employee.education_level %}selected{% endif %}>Select Education Level</option>
@@ -244,6 +244,17 @@
                             <option value="Trade School" {% if employee and employee.education_level == 'Trade School' %}selected{% endif %}>Trade School</option>
                             <option value="Certification" {% if employee and employee.education_level == 'Certification' %}selected{% endif %}>Certification</option>
                             <option value="Other" {% if employee and employee.education_level == 'Other' %}selected{% endif %}>Other</option>
+                        </select>
+                    </div>
+
+                    <!-- Employment Type -->
+                    <div class="col-md-4 mb-3">
+                        <label for="employment_type" class="form-label">Employment Type</label>
+                        <select class="form-select" id="employment_type" name="employment_type">
+                            <option value="" {% if not employee or not employee.employment_type %}selected{% endif %}>Select Type</option>
+                            <option value="Full-time" {% if employee and employee.employment_type == 'Full-time' %}selected{% endif %}>Full-time</option>
+                            <option value="Part-time" {% if employee and employee.employment_type == 'Part-time' %}selected{% endif %}>Part-time</option>
+                            <option value="Consultant" {% if employee and employee.employment_type == 'Consultant' %}selected{% endif %}>Consultant</option>
                         </select>
                     </div>
                 </div>

--- a/templates/employees/profile.html
+++ b/templates/employees/profile.html
@@ -179,6 +179,12 @@
                         <h6><i class="fas fa-level-up-alt mr-2"></i> Employee Level</h6>
                         <p>{{ employee.level if employee.level else 'Not specified' }}</p>
                     </div>
+
+                    <!-- Employment Type -->
+                    <div class="mb-3">
+                        <h6><i class="fas fa-briefcase mr-2"></i> Employment Type</h6>
+                        <p>{{ employee.employment_type if employee.employment_type else 'Not specified' }}</p>
+                    </div>
                     
                     <!-- Is Manager -->
                     <div class="mb-3">


### PR DESCRIPTION
## Summary
- include employment type field in employee edit form
- display employment type on employee profile page
- save employment type in employee routes

## Testing
- `pytest -q` *(fails: command not found)*