### PR TITLE
Add compensation info to employee profiles

### DIFF
--- a/templates/employees/profile.html
+++ b/templates/employees/profile.html
@@ -185,6 +185,20 @@
                         <h6><i class="fas fa-briefcase mr-2"></i> Employment Type</h6>
                         <p>{{ employee.employment_type if employee.employment_type else 'Not specified' }}</p>
                     </div>
+
+                    <!-- Pay Type -->
+                    <div class="mb-3">
+                        <h6><i class="fas fa-wallet mr-2"></i> Pay Type</h6>
+                        <p>{{ 'Salary' if employee.salary_type == 'Annual' else 'Hourly' }}</p>
+                    </div>
+
+                    <!-- Base Pay -->
+                    <div class="mb-3">
+                        <h6><i class="fas fa-dollar-sign mr-2"></i> Base {{ 'Salary' if employee.salary_type == 'Annual' else 'Hourly Wage' }}</h6>
+                        <p>
+                            ${{ "{:,.2f}".format(employee.base_salary) }}{% if employee.salary_type == 'Hourly' %}/hr{% else %}/yr{% endif %}
+                        </p>
+                    </div>
                     
                     <!-- Is Manager -->
                     <div class="mb-3">
@@ -233,6 +247,42 @@
                         <p>None</p>
                         {% endif %}
                     </div>
+                </div>
+            </div>
+
+            <!-- Compensation History -->
+            <div class="card shadow profile-detail-card mt-4">
+                <div class="card-header py-3">
+                    <h6 class="m-0 fw-bold">Compensation History</h6>
+                </div>
+                <div class="card-body">
+                    {% set comp_history = employee.compensations.order_by(models.EmployeeCompensation.effective_date.desc()).all() %}
+                    {% if comp_history %}
+                    <div class="table-responsive">
+                        <table class="table table-sm">
+                            <thead>
+                                <tr>
+                                    <th>Effective Date</th>
+                                    <th>End Date</th>
+                                    <th>Type</th>
+                                    <th>Amount</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for comp in comp_history %}
+                                <tr>
+                                    <td>{{ comp.effective_date.strftime('%Y-%m-%d') }}</td>
+                                    <td>{{ comp.end_date.strftime('%Y-%m-%d') if comp.end_date else 'Present' }}</td>
+                                    <td>{{ 'Salary' if comp.salary_type == 'Annual' else 'Hourly' }}</td>
+                                    <td>${{ "{:,.2f}".format(comp.base_salary) }}{% if comp.salary_type == 'Hourly' %}/hr{% else %}/yr{% endif %}</td>
+                                </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                    {% else %}
+                    <p class="text-center text-muted my-3">No compensation history found.</p>
+                    {% endif %}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- show pay type and base pay in the employment detail card
- add a compensation history table on employee profiles

## Testing
- `pytest -q` *(fails: command not found)*