### PR TITLE
Enable employee access to compensation reports

### DIFF
--- a/add_employee_visibility_to_compensation_reports.py
+++ b/add_employee_visibility_to_compensation_reports.py
@@ -1,0 +1,23 @@
+"""Migration script to add is_visible_to_employee column to compensation_reports table."""
+from app import app, db
+from sqlalchemy import text
+
+
+def add_visibility_column():
+    """Add is_visible_to_employee column if it doesn't exist."""
+    with app.app_context():
+        inspector = db.inspect(db.engine)
+        columns = [col['name'] for col in inspector.get_columns('compensation_reports')]
+
+        if 'is_visible_to_employee' not in columns:
+            print("Adding is_visible_to_employee column to compensation_reports table...")
+            with db.engine.connect() as conn:
+                conn.execute(text("ALTER TABLE compensation_reports ADD COLUMN is_visible_to_employee BOOLEAN DEFAULT FALSE"))
+                conn.commit()
+            print("Column added successfully.")
+        else:
+            print("is_visible_to_employee column already exists in compensation_reports table.")
+
+
+if __name__ == '__main__':
+    add_visibility_column()

--- a/models.py
+++ b/models.py
@@ -658,6 +658,7 @@ class CompensationReport(db.Model):
     employer_benefit_contributions = db.Column(db.Float, default=0.0)
     total_compensation = db.Column(db.Float, nullable=False)
     report_file_path = db.Column(db.String(255))
+    is_visible_to_employee = db.Column(db.Boolean, default=False)
     created_by = db.Column(db.Integer, db.ForeignKey('users.id'))
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     

--- a/routes/budgeting.py
+++ b/routes/budgeting.py
@@ -577,6 +577,7 @@ def generate_compensation_reports():
                     existing_report.total_deductions = total_deductions
                     existing_report.employer_benefit_contributions = benefits_cost
                     existing_report.total_compensation = total_compensation
+                    existing_report.is_visible_to_employee = True
                     existing_report.created_by = current_user.id
                     existing_report.created_at = datetime.utcnow()
                 else:
@@ -590,6 +591,7 @@ def generate_compensation_reports():
                         total_deductions=total_deductions,
                         employer_benefit_contributions=benefits_cost,
                         total_compensation=total_compensation,
+                        is_visible_to_employee=True,
                         created_by=current_user.id
                     )
                     db.session.add(report)

--- a/routes/payroll.py
+++ b/routes/payroll.py
@@ -649,6 +649,35 @@ def my_compensation():
                           benefits=benefits)
 
 
+@payroll.route('/my-compensation-report')
+@login_required
+def my_compensation_report():
+    """View generated compensation report for the current employee."""
+    employee = get_current_employee()
+
+    if not employee:
+        flash('No employee profile found for your account', 'warning')
+        return redirect(url_for('payroll.index'))
+
+    year = request.args.get('year', datetime.now().year, type=int)
+
+    report = CompensationReport.query.filter_by(
+        employee_id=employee.id,
+        year=year,
+        is_visible_to_employee=True,
+    ).first()
+
+    if not report:
+        flash('Compensation report not available.', 'warning')
+        return redirect(url_for('payroll.my_compensation'))
+
+    return render_template(
+        'payroll/my_compensation_report.html',
+        employee=employee,
+        report=report,
+    )
+
+
 @payroll.route('/salary-structures')
 @login_required
 @role_required('Admin', 'HR')

--- a/templates/payroll/index.html
+++ b/templates/payroll/index.html
@@ -250,7 +250,7 @@
                         <a href="{{ url_for('payroll.my_payslips') }}" class="btn btn-primary">
                             <i class="fas fa-file-invoice-dollar me-2"></i> View My Payslips
                         </a>
-                        <a href="{{ url_for('payroll.my_compensation') }}" class="btn btn-outline-primary">
+                        <a href="{{ url_for('payroll.my_compensation_report') }}" class="btn btn-outline-primary">
                             <i class="fas fa-chart-bar me-2"></i> Compensation Report
                         </a>
                     </div>

--- a/templates/payroll/my_compensation.html
+++ b/templates/payroll/my_compensation.html
@@ -11,6 +11,9 @@
             <a href="{{ url_for('payroll.my_payslips') }}" class="btn btn-secondary me-2">
                 <i class="fas fa-file-invoice-dollar me-1"></i> View Payslips
             </a>
+            <a href="{{ url_for('payroll.my_compensation_report') }}" class="btn btn-primary me-2">
+                <i class="fas fa-file-alt me-1"></i> Annual Report
+            </a>
             <a href="{{ url_for('payroll.index') }}" class="btn btn-outline-secondary">
                 <i class="fas fa-arrow-left me-1"></i> Back to Payroll Dashboard
             </a>

--- a/templates/payroll/my_compensation_report.html
+++ b/templates/payroll/my_compensation_report.html
@@ -1,0 +1,67 @@
+{% extends "layout.html" %}
+
+{% block title %}My Compensation Report{% endblock %}
+
+{% block content %}
+<div class="container-fluid">
+    <div class="d-flex justify-content-between align-items-center mb-4">
+        <h1 class="h3 mb-0 text-light">My Compensation Report ({{ report.year }})</h1>
+        <div>
+            <a href="{{ url_for('payroll.my_compensation') }}" class="btn btn-secondary me-2">
+                <i class="fas fa-chart-pie me-1"></i> Compensation Summary
+            </a>
+            <a href="{{ url_for('payroll.index') }}" class="btn btn-outline-secondary">
+                <i class="fas fa-arrow-left me-1"></i> Back to Payroll Dashboard
+            </a>
+        </div>
+    </div>
+
+    <div class="card shadow mb-4">
+        <div class="card-header py-3">
+            <h6 class="m-0 fw-bold">Report Details</h6>
+        </div>
+        <div class="card-body">
+            <div class="table-responsive">
+                <table class="table table-striped">
+                    <tbody>
+                        <tr>
+                            <th scope="row">Base Salary</th>
+                            <td>{{ report.base_salary|format_currency }}</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">Total Bonus</th>
+                            <td>{{ report.total_bonus|format_currency }}</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">Total Allowances</th>
+                            <td>{{ report.total_allowances|format_currency }}</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">Total Deductions</th>
+                            <td>{{ report.total_deductions|format_currency }}</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">Employer Benefit Contributions</th>
+                            <td>{{ report.employer_benefit_contributions|format_currency }}</td>
+                        </tr>
+                        <tr class="table-primary">
+                            <th scope="row">Total Compensation</th>
+                            <td>{{ report.total_compensation|format_currency }}</td>
+                        </tr>
+                        {% if report.report_file_path %}
+                        <tr>
+                            <th scope="row">Report File</th>
+                            <td>
+                                <a href="{{ report.report_file_path }}" class="btn btn-sm btn-primary" download>
+                                    <i class="fas fa-download me-1"></i> Download PDF
+                                </a>
+                            </td>
+                        </tr>
+                        {% endif %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/payroll/my_payslips.html
+++ b/templates/payroll/my_payslips.html
@@ -186,7 +186,7 @@
                     </ul>
                     
                     <div class="d-grid gap-2 mt-3">
-                        <a href="{{ url_for('payroll.my_compensation') }}" class="btn btn-primary">
+                        <a href="{{ url_for('payroll.my_compensation_report') }}" class="btn btn-primary">
                             <i class="fas fa-chart-pie me-2"></i> View Compensation Report
                         </a>
                     </div>


### PR DESCRIPTION
## Summary
- add `is_visible_to_employee` field to `CompensationReport`
- migration script to add the new column
- generate reports with visibility enabled
- employee route and template for viewing their annual compensation report
- link the report from payroll pages

## Testing
- `pytest -q` *(fails: command not found)*