### PR TITLE
Add payslip edit functionality

### DIFF
--- a/templates/payroll/edit_payslip.html
+++ b/templates/payroll/edit_payslip.html
@@ -1,0 +1,35 @@
+{% extends "layout.html" %}
+
+{% block title %}Edit Payslip{% endblock %}
+
+{% block content %}
+<div class="container-fluid">
+    <h1 class="h3 mb-4 text-light">Edit Payslip</h1>
+    <form method="post">
+        <div class="table-responsive mb-3">
+            <table class="table">
+                <thead>
+                    <tr>
+                        <th>Description</th>
+                        <th>Type</th>
+                        <th class="text-end">Amount</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for entry in entries %}
+                    <tr>
+                        <td>{{ entry.component_name }}</td>
+                        <td>{{ entry.type }}</td>
+                        <td class="text-end" style="max-width:150px;">
+                            <input type="number" step="0.01" name="amount_{{ entry.id }}" class="form-control text-end" value="{{ entry.amount }}">
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        <button type="submit" class="btn btn-primary">Save Changes</button>
+        <a href="{{ url_for('payroll.view_payslip', payroll_id=payslip.id) }}" class="btn btn-secondary">Cancel</a>
+    </form>
+</div>
+{% endblock %}

--- a/tests/test_edit_payslip.py
+++ b/tests/test_edit_payslip.py
@@ -1,0 +1,104 @@
+import os
+import datetime
+import pytest
+
+os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+os.environ['SESSION_SECRET'] = 'testing'
+
+import app
+from app import db
+from models import Role, User, Employee, EmployeeCompensation, PayPeriod, Payroll, PayrollEntry
+
+
+@pytest.fixture
+def client():
+    app.app.config['TESTING'] = True
+    app.app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+
+    with app.app.app_context():
+        db.drop_all()
+        db.create_all()
+
+        admin_role = Role(name='Admin')
+        db.session.add(admin_role)
+        db.session.commit()
+
+        admin_user = User(username='admin', email='admin@example.com', role_id=admin_role.id, is_active=True)
+        admin_user.set_password('password')
+        db.session.add(admin_user)
+        db.session.commit()
+
+        employee = Employee(
+            employee_id='EMP001',
+            first_name='Test',
+            last_name='Employee',
+            email='employee@example.com',
+            hire_date=datetime.date.today(),
+            status='Active'
+        )
+        db.session.add(employee)
+        db.session.commit()
+
+        comp = EmployeeCompensation(
+            employee_id=employee.id,
+            base_salary=52000.0,
+            salary_type='Annual',
+            effective_date=datetime.date.today()
+        )
+        db.session.add(comp)
+        db.session.commit()
+
+        period = PayPeriod(
+            start_date=datetime.date.today(),
+            end_date=datetime.date.today() + datetime.timedelta(days=14),
+            status='Processing'
+        )
+        db.session.add(period)
+        db.session.commit()
+
+        payroll = Payroll(
+            employee_id=employee.id,
+            pay_period_id=period.id,
+            gross_pay=1000.0,
+            tax_amount=200.0,
+            total_deductions=50.0,
+            net_pay=750.0,
+            status='Pending'
+        )
+        db.session.add(payroll)
+        db.session.commit()
+
+        e1 = PayrollEntry(payroll_id=payroll.id, component_name='Base Salary', type='Earning', amount=1000.0)
+        e2 = PayrollEntry(payroll_id=payroll.id, component_name='Income Tax', type='Deduction', amount=200.0)
+        e3 = PayrollEntry(payroll_id=payroll.id, component_name='Other Deduction', type='Deduction', amount=50.0)
+        db.session.add_all([e1, e2, e3])
+        db.session.commit()
+
+    with app.app.test_client() as client:
+        client.post('/login', data={'username': 'admin', 'password': 'password'})
+        yield client, payroll, (e1, e2, e3)
+
+        with app.app.app_context():
+            db.session.remove()
+            db.drop_all()
+
+
+def test_edit_payslip_updates_amounts(client):
+    client_obj, payroll, entries = client
+    e1, e2, e3 = entries
+
+    data = {
+        f'amount_{e1.id}': '1200',
+        f'amount_{e2.id}': '240',
+        f'amount_{e3.id}': '60',
+    }
+
+    resp = client_obj.post(f'/payroll/payslips/{payroll.id}/edit', data=data)
+    assert resp.status_code in (302, 200)
+
+    with app.app.app_context():
+        updated = Payroll.query.get(payroll.id)
+        assert updated.gross_pay == 1200.0
+        assert updated.tax_amount == 240.0
+        assert updated.total_deductions == 60.0
+        assert updated.net_pay == 900.0


### PR DESCRIPTION
## Summary
- allow admins/HR to edit payslip entries
- create `edit_payslip.html` form template
- test editing updates payroll totals correctly

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*