### PR TITLE
Consolidate allowed_file helper

### DIFF
--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -8,10 +8,24 @@ from werkzeug.utils import secure_filename
 
 ALLOWED_EXTENSIONS = {'pdf', 'doc', 'docx', 'xls', 'xlsx', 'txt', 'csv'}
 
-def allowed_file(filename):
-    """Check if the file extension is allowed"""
-    return '.' in filename and \
-           filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
+def allowed_file(filename, allowed_extensions=None):
+    """Check if the file extension is allowed.
+
+    Args:
+        filename (str): Name of the file to validate.
+        allowed_extensions (set[str] | None): Optional custom allowed
+            extensions. Defaults to ``ALLOWED_EXTENSIONS``.
+
+    Returns:
+        bool: ``True`` if the extension is allowed, otherwise ``False``.
+    """
+    if allowed_extensions is None:
+        allowed_extensions = ALLOWED_EXTENSIONS
+
+    return (
+        '.' in filename
+        and filename.rsplit('.', 1)[1].lower() in allowed_extensions
+    )
 
 def save_document(file, upload_folder):
     """Save uploaded document and return secure filename"""

--- a/utils/importers.py
+++ b/utils/importers.py
@@ -8,12 +8,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from flask import flash
 from app import db
 from models import Employee, Department, User, Role
-
-def allowed_file(filename, allowed_extensions=None):
-    """Check if the file extension is allowed."""
-    if allowed_extensions is None:
-        allowed_extensions = {'csv', 'xlsx', 'xls'}
-    return '.' in filename and filename.rsplit('.', 1)[1].lower() in allowed_extensions
+from utils.helpers import allowed_file
 
 def process_employee_import(file, upload_folder):
     """Process employee import from CSV or Excel file.
@@ -25,7 +20,7 @@ def process_employee_import(file, upload_folder):
     Returns:
         tuple: (success_count, error_count, errors)
     """
-    if file and allowed_file(file.filename):
+    if file and allowed_file(file.filename, {'csv', 'xlsx', 'xls'}):
         # Create upload directory if it doesn't exist
         os.makedirs(upload_folder, exist_ok=True)
         


### PR DESCRIPTION
## Summary
- centralize `allowed_file` in `utils/helpers.py`
- import the helper in `utils/importers.py`

## Testing
- `pytest -q` *(fails: pytest not installed)*