### PR TITLE
Refactor timesheet view helpers

### DIFF
--- a/tests/test_timesheet_service.py
+++ b/tests/test_timesheet_service.py
@@ -1,0 +1,90 @@
+import os
+import datetime
+import sqlalchemy
+import pytest
+
+os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+os.environ['SESSION_SECRET'] = 'testing'
+
+import app
+from app import db
+from models import Role, User, Employee, PayPeriod, Timesheet, TimeEntry
+from utils.timesheet_service import TimesheetService
+
+@pytest.fixture()
+def setup_env():
+    app.app.config.update(
+        TESTING=True,
+        SQLALCHEMY_DATABASE_URI='sqlite:///:memory:',
+        SQLALCHEMY_ENGINE_OPTIONS={
+            'connect_args': {'check_same_thread': False},
+            'poolclass': sqlalchemy.pool.StaticPool,
+        },
+    )
+    with app.app.app_context():
+        db.drop_all()
+        db.create_all()
+        role = Role(name='Admin')
+        db.session.add(role)
+        db.session.commit()
+
+        user = User(username='admin', email='admin@example.com', role_id=role.id, is_active=True)
+        user.set_password('password')
+        db.session.add(user)
+        db.session.commit()
+
+        emp_a = Employee(employee_id='A', first_name='A', last_name='A', email='a@x.com', hire_date=datetime.date.today(), status='Active')
+        emp_b = Employee(employee_id='B', first_name='B', last_name='B', email='b@x.com', hire_date=datetime.date.today(), status='Active')
+        emp_c = Employee(employee_id='C', first_name='C', last_name='C', email='c@x.com', hire_date=datetime.date.today(), status='Active')
+        db.session.add_all([emp_a, emp_b, emp_c])
+        db.session.commit()
+
+        period = PayPeriod(start_date=datetime.date.today(), end_date=datetime.date.today() + datetime.timedelta(days=1), status='Open')
+        db.session.add(period)
+        db.session.commit()
+
+        timesheet = Timesheet(employee_id=emp_b.id, pay_period_id=period.id)
+        db.session.add(timesheet)
+        db.session.commit()
+
+        yield user, timesheet, period, emp_a, emp_b, emp_c
+        db.session.remove()
+        db.drop_all()
+
+
+def test_navigation_links(setup_env):
+    user, timesheet, _, emp_a, emp_b, emp_c = setup_env
+    with app.app.app_context():
+        prev_emp, next_emp = TimesheetService.get_navigation(timesheet, user)
+        assert prev_emp.id == emp_a.id
+        assert next_emp.id == emp_c.id
+
+
+def test_update_entries_and_submit(setup_env):
+    user, timesheet, period, *_ = setup_env
+    with app.app.app_context():
+        form = {
+            f"hours_{period.start_date.strftime('%Y-%m-%d')}": '4',
+            f"description_{period.start_date.strftime('%Y-%m-%d')}": 'work',
+            f"hours_{(period.start_date + datetime.timedelta(days=1)).strftime('%Y-%m-%d')}": '5',
+            f"description_{(period.start_date + datetime.timedelta(days=1)).strftime('%Y-%m-%d')}": 'more',
+        }
+        TimesheetService.update_entries_from_form(timesheet, form)
+        entries = TimeEntry.query.filter_by(timesheet_id=timesheet.id).order_by(TimeEntry.date).all()
+        assert len(entries) == 2
+        assert timesheet.total_hours == 9
+
+        TimesheetService.submit_timesheet(timesheet)
+        assert timesheet.status == 'Submitted'
+        assert timesheet.submitted_at is not None
+
+
+def test_approve_timesheet(setup_env):
+    user, timesheet, period, *_ = setup_env
+    with app.app.app_context():
+        form = {f"hours_{period.start_date.strftime('%Y-%m-%d')}": '1'}
+        TimesheetService.update_entries_from_form(timesheet, form)
+        TimesheetService.submit_timesheet(timesheet)
+        TimesheetService.approve_timesheet(timesheet, user.id, 'ok')
+        assert timesheet.status == 'Approved'
+        assert timesheet.approved_by == user.id

--- a/utils/timesheet_service.py
+++ b/utils/timesheet_service.py
@@ -1,0 +1,90 @@
+"""Service helpers for timesheet operations."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Iterable, Tuple
+
+from app import db
+from models import Employee, TimeEntry, Timesheet
+from sqlalchemy import func
+
+
+class TimesheetService:
+    """Utility methods for timesheet management."""
+
+    @staticmethod
+    def get_navigation(timesheet: Timesheet, user) -> Tuple[Employee | None, Employee | None]:
+        """Return previous and next employees for navigation."""
+        prev_employee = None
+        next_employee = None
+
+        if user.role.name in ['Admin', 'HR']:
+            employees = Employee.query.order_by(Employee.last_name, Employee.first_name).all()
+            employee_ids = [e.id for e in employees]
+        elif user.employee and user.employee.id == timesheet.employee.manager_id:
+            direct_reports = Employee.query.filter_by(manager_id=user.employee.id).order_by(Employee.last_name, Employee.first_name).all()
+            employee_ids = [e.id for e in direct_reports]
+        else:
+            return None, None
+
+        if timesheet.employee_id in employee_ids:
+            idx = employee_ids.index(timesheet.employee_id)
+            if idx > 0:
+                prev_employee = Employee.query.get(employee_ids[idx - 1])
+            if idx < len(employee_ids) - 1:
+                next_employee = Employee.query.get(employee_ids[idx + 1])
+
+        return prev_employee, next_employee
+
+    @staticmethod
+    def update_entries_from_form(timesheet: Timesheet, form: dict) -> None:
+        """Update timesheet entries based on submitted form data."""
+        start_date = timesheet.pay_period.start_date
+        end_date = timesheet.pay_period.end_date
+        current_date = start_date
+
+        while current_date <= end_date:
+            date_str = current_date.strftime('%Y-%m-%d')
+            hours_raw = form.get(f'hours_{date_str}', '0')
+            description = form.get(f'description_{date_str}', '')
+            entry = TimeEntry.query.filter_by(timesheet_id=timesheet.id, date=current_date).first()
+            try:
+                hours_val = float(hours_raw) if hours_raw else 0
+            except ValueError:
+                hours_val = 0
+
+            if entry:
+                entry.hours = hours_val
+                entry.description = description
+            else:
+                if hours_val > 0 or description:
+                    entry = TimeEntry(timesheet_id=timesheet.id, date=current_date, hours=hours_val, description=description)
+                    db.session.add(entry)
+
+            current_date += timedelta(days=1)
+
+        # Recalculate total hours
+        timesheet.total_hours = db.session.query(func.sum(TimeEntry.hours)).filter(TimeEntry.timesheet_id == timesheet.id).scalar() or 0
+        db.session.commit()
+
+    @staticmethod
+    def submit_timesheet(timesheet: Timesheet) -> None:
+        """Mark timesheet as submitted."""
+        entry_count = TimeEntry.query.filter_by(timesheet_id=timesheet.id).count()
+        if entry_count == 0:
+            raise ValueError('Cannot submit an empty timesheet.')
+        timesheet.status = 'Submitted'
+        timesheet.submitted_at = datetime.now()
+        timesheet.total_hours = db.session.query(func.sum(TimeEntry.hours)).filter(TimeEntry.timesheet_id == timesheet.id).scalar() or 0
+        db.session.commit()
+
+    @staticmethod
+    def approve_timesheet(timesheet: Timesheet, approver_id: int, comments: str = '') -> None:
+        """Approve a submitted timesheet."""
+        if timesheet.status != 'Submitted':
+            raise ValueError('Only submitted timesheets can be approved.')
+        timesheet.status = 'Approved'
+        timesheet.approved_by = approver_id
+        timesheet.approved_at = datetime.now()
+        timesheet.comments = comments
+        db.session.commit()


### PR DESCRIPTION
## Summary
- factor out timesheet navigation and form handling
- add `TimesheetService` with helpers for navigation, entry updates and status changes
- use `TimesheetService` in routes
- add unit tests for service helpers

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*