### PR TITLE
Fix documents route circular import

### DIFF
--- a/create_pay_periods.py
+++ b/create_pay_periods.py
@@ -2,17 +2,19 @@
 Script to create initial pay periods for the timesheet system.
 """
 from datetime import datetime, timedelta
-from app import app, db
+from flask import current_app
+from app import db
 from models import PayPeriod
 
-def create_initial_pay_periods(start_date_str=None):
+def create_initial_pay_periods(start_date_str=None, app=None):
     """Create initial pay periods for the timesheet system.
     
     Args:
         start_date_str: Optional start date in 'YYYY-MM-DD' format.
                       If not provided, will use the first Monday of the current year.
     """
-    with app.app_context():
+    target_app = app or current_app
+    with target_app.app_context():
         # Check if there are existing pay periods
         existing_count = PayPeriod.query.count()
         if existing_count > 0:
@@ -83,4 +85,6 @@ def create_initial_pay_periods(start_date_str=None):
             print(f"Period {period.id}: {period.start_date} to {period.end_date} - {status_str}")
 
 if __name__ == "__main__":
-    create_initial_pay_periods()
+    from app import create_app
+    app = create_app()
+    create_initial_pay_periods(app=app)

--- a/routes/documents.py
+++ b/routes/documents.py
@@ -1,9 +1,9 @@
 import os
-from flask import Blueprint, render_template, request, redirect, url_for, flash, send_file, abort, jsonify
+from flask import Blueprint, render_template, request, redirect, url_for, flash, send_file, abort, jsonify, current_app
 from flask_login import login_required, current_user
 from werkzeug.utils import secure_filename
 from sqlalchemy.exc import SQLAlchemyError
-from app import app, db
+from app import db
 from models import Document, Employee, DocumentType
 from utils.helpers import role_required, allowed_file, save_document
 
@@ -130,7 +130,7 @@ def upload_document():
             
             # Save file
             if file and allowed_file(file.filename):
-                filename = save_document(file, app.config['UPLOAD_FOLDER'])
+                filename = save_document(file, current_app.config['UPLOAD_FOLDER'])
                 
                 if filename:
                     # We don't need to check document type ID since we don't have that column
@@ -200,7 +200,7 @@ def download_document(document_id):
             return redirect(url_for('documents.index'))
     
     try:
-        file_path = os.path.join(app.config['UPLOAD_FOLDER'], document.file_path)
+        file_path = os.path.join(current_app.config['UPLOAD_FOLDER'], document.file_path)
         if os.path.exists(file_path):
             return send_file(
                 file_path,
@@ -223,7 +223,7 @@ def delete_document(document_id):
     
     try:
         # Delete file from filesystem
-        file_path = os.path.join(app.config['UPLOAD_FOLDER'], document.file_path)
+        file_path = os.path.join(current_app.config['UPLOAD_FOLDER'], document.file_path)
         if os.path.exists(file_path):
             os.remove(file_path)
         


### PR DESCRIPTION
## Summary
- remove global `app` import from `routes/documents.py`
- use `current_app` to access config
- avoid circular import in `create_pay_periods` script

## Testing
- `pytest -q` *(fails: command not found)*