### PR TITLE
Implement bottom up payroll budgeting

### DIFF
--- a/app/templates/budgeting/projection.html
+++ b/app/templates/budgeting/projection.html
@@ -168,9 +168,9 @@
                         <tr class="fw-bold">
                             <td colspan="3">TOTALS</td>
                             <td>${{ "{:,.2f}".format(total_salary) }}</td>
-                            <td>${{ "{:,.2f}".format(total_benefits * 0.3) }}</td>
+                            <td>${{ "{:,.2f}".format(total_retirement) }}</td>
                             <td>${{ "{:,.2f}".format(total_taxes) }}</td>
-                            <td>${{ "{:,.2f}".format(total_benefits * 0.7) }}</td>
+                            <td>${{ "{:,.2f}".format(total_healthcare) }}</td>
                             <td>${{ "{:,.2f}".format(total_cost) }}</td>
                         </tr>
                     </tfoot>
@@ -200,10 +200,10 @@
                         
                         <div class="d-flex justify-content-between align-items-center">
                             <span>Retirement Contributions</span>
-                            <span>{{ "{:.1f}".format(total_benefits * 0.3 / total_cost * 100) }}%</span>
+                            <span>{{ "{:.1f}".format(total_retirement / total_cost * 100) }}%</span>
                         </div>
                         <div class="progress mb-4">
-                            <div class="progress-bar bg-success" role="progressbar" style="width: {{ total_benefits * 0.3 / total_cost * 100 }}%">
+                            <div class="progress-bar bg-success" role="progressbar" style="width: {{ total_retirement / total_cost * 100 }}%">
                             </div>
                         </div>
                         
@@ -218,10 +218,10 @@
                         
                         <div class="d-flex justify-content-between align-items-center">
                             <span>Health & Other Benefits</span>
-                            <span>{{ "{:.1f}".format(total_benefits * 0.7 / total_cost * 100) }}%</span>
+                            <span>{{ "{:.1f}".format(total_healthcare / total_cost * 100) }}%</span>
                         </div>
                         <div class="progress mb-4">
-                            <div class="progress-bar bg-warning" role="progressbar" style="width: {{ total_benefits * 0.7 / total_cost * 100 }}%">
+                            <div class="progress-bar bg-warning" role="progressbar" style="width: {{ total_healthcare / total_cost * 100 }}%">
                             </div>
                         </div>
                     </div>
@@ -239,11 +239,11 @@
                         <h5><i class="fas fa-info-circle"></i> Projection Details</h5>
                         <p>This projection is based on the following assumptions:</p>
                         <ul>
-                            <li><strong>401(k) Match:</strong> 3% of base salary</li>
+                            <li><strong>401(k) Match:</strong> 4% of base salary (if enrolled)</li>
                             <li><strong>FICA:</strong> 7.65% of salary (6.2% Social Security + 1.45% Medicare)</li>
                             <li><strong>FUTA:</strong> 0.6% on first $7,000 of wages</li>
                             <li><strong>SUTA:</strong> 3.5% of taxable wages (varies by state)</li>
-                            <li><strong>Health Insurance:</strong> Based on current enrollment</li>
+                            <li><strong>Health Insurance:</strong> Placeholder estimate</li>
                             <li><strong>Other Benefits:</strong> Includes life insurance, disability, etc.</li>
                         </ul>
                         <p class="mb-0">

--- a/app/templates/employees/profile.html
+++ b/app/templates/employees/profile.html
@@ -199,6 +199,12 @@
                             ${{ "{:,.2f}".format(employee.base_salary) }}{% if employee.salary_type == 'Hourly' %}/hr{% else %}/yr{% endif %}
                         </p>
                     </div>
+                    {% if employee.salary_type == 'Hourly' %}
+                    <div class="mb-3">
+                        <h6><i class="fas fa-clock mr-2"></i> Hours per Week</h6>
+                        <p>{{ employee.hours_per_week }}</p>
+                    </div>
+                    {% endif %}
                     
                     <!-- Is Manager -->
                     <div class="mb-3">

--- a/app/templates/payroll/create_compensation.html
+++ b/app/templates/payroll/create_compensation.html
@@ -26,6 +26,10 @@
             <input type="number" step="0.01" name="base_salary" class="form-control" required>
         </div>
         <div class="mb-3">
+            <label class="form-label">Hours per Week (if hourly)</label>
+            <input type="number" step="0.1" name="hours_per_week" class="form-control">
+        </div>
+        <div class="mb-3">
             <label class="form-label">Effective Date</label>
             <input type="date" name="effective_date" class="form-control" required>
         </div>

--- a/app/templates/payroll/my_compensation.html
+++ b/app/templates/payroll/my_compensation.html
@@ -38,7 +38,7 @@
                                     <hr>
                                     <div class="d-flex justify-content-between mb-2">
                                         <span>Base Salary</span>
-                                        <span class="fw-bold">${{ "{:,.2f}".format(employee.base_salary if employee.salary_type == 'Annual' else employee.base_salary * 2080) }}</span>
+                                        <span class="fw-bold">${{ "{:,.2f}".format(employee.annual_base_salary) }}</span>
                                     </div>
                                     
                                     {% set total_bonuses = 0 %}
@@ -75,7 +75,7 @@
                                     
                                     <hr>
                                     
-                                    {% set total_compensation = employee.base_salary if employee.salary_type == 'Annual' else employee.base_salary * 2080 %}
+                                    {% set total_compensation = employee.annual_base_salary %}
                                     {% set total_compensation = total_compensation + total_bonuses + total_allowances + total_benefits %}
                                     
                                     <div class="d-flex justify-content-between">
@@ -93,7 +93,7 @@
                                     <h5 class="fw-bold text-primary">Bi-Weekly Pay</h5>
                                     <hr>
                                     
-                                    {% set biweekly_base = employee.base_salary / 26 if employee.salary_type == 'Annual' else employee.base_salary * 80 %}
+                                    {% set biweekly_base = employee.annual_base_salary / 26 %}
                                     
                                     <div class="d-flex justify-content-between mb-2">
                                         <span>Base Pay</span>

--- a/models/compensation.py
+++ b/models/compensation.py
@@ -60,6 +60,7 @@ class EmployeeCompensation(db.Model):
     employee_id = db.Column(db.Integer, db.ForeignKey('employees.id'), nullable=False)
     base_salary = db.Column(db.Float, nullable=False)
     salary_type = db.Column(db.String(20), default='Annual')
+    hours_per_week = db.Column(db.Float, default=40.0)
     effective_date = db.Column(db.Date, nullable=False)
     end_date = db.Column(db.Date)
     salary_structure_id = db.Column(db.Integer, db.ForeignKey('salary_structures.id'))

--- a/models/employees.py
+++ b/models/employees.py
@@ -94,6 +94,23 @@ class Employee(db.Model):
         return getattr(compensation, 'salary_type', 'Annual') if compensation else ''
 
     @property
+    def hours_per_week(self) -> float:
+        compensation = self.current_compensation
+        if compensation and compensation.hours_per_week:
+            return compensation.hours_per_week
+        return 40.0
+
+    @property
+    def annual_base_salary(self) -> float:
+        comp = self.current_compensation
+        if not comp:
+            return 0.0
+        if comp.salary_type == 'Annual':
+            return comp.base_salary
+        hours = comp.hours_per_week or 40.0
+        return comp.base_salary * hours * 52
+
+    @property
     def years_of_service(self) -> int:
         if not self.hire_date:
             return 0

--- a/models/models/compensation.py
+++ b/models/models/compensation.py
@@ -60,6 +60,7 @@ class EmployeeCompensation(db.Model):
     employee_id = db.Column(db.Integer, db.ForeignKey('employees.id'), nullable=False)
     base_salary = db.Column(db.Float, nullable=False)
     salary_type = db.Column(db.String(20), default='Annual')
+    hours_per_week = db.Column(db.Float, default=40.0)
     effective_date = db.Column(db.Date, nullable=False)
     end_date = db.Column(db.Date)
     salary_structure_id = db.Column(db.Integer, db.ForeignKey('salary_structures.id'))

--- a/models/models/employees.py
+++ b/models/models/employees.py
@@ -94,6 +94,23 @@ class Employee(db.Model):
         return getattr(compensation, 'salary_type', 'Annual') if compensation else ''
 
     @property
+    def hours_per_week(self) -> float:
+        compensation = self.current_compensation
+        if compensation and compensation.hours_per_week:
+            return compensation.hours_per_week
+        return 40.0
+
+    @property
+    def annual_base_salary(self) -> float:
+        comp = self.current_compensation
+        if not comp:
+            return 0.0
+        if comp.salary_type == 'Annual':
+            return comp.base_salary
+        hours = comp.hours_per_week or 40.0
+        return comp.base_salary * hours * 52
+
+    @property
     def years_of_service(self) -> int:
         if not self.hire_date:
             return 0

--- a/models/routes/payroll.py
+++ b/models/routes/payroll.py
@@ -913,6 +913,7 @@ def create_compensation():
         employee_id = request.form.get('employee_id', type=int)
         base_salary = request.form.get('base_salary', type=float)
         salary_type = request.form.get('salary_type') or 'Annual'
+        hours_per_week = request.form.get('hours_per_week', type=float)
         effective_date = request.form.get('effective_date')
         end_date = request.form.get('end_date')
         salary_structure_id = request.form.get('salary_structure_id', type=int)
@@ -926,6 +927,7 @@ def create_compensation():
                 employee_id=employee_id,
                 base_salary=base_salary,
                 salary_type=salary_type,
+                hours_per_week=hours_per_week,
                 effective_date=datetime.strptime(effective_date, '%Y-%m-%d').date(),
                 end_date=datetime.strptime(end_date, '%Y-%m-%d').date() if end_date else None,
                 salary_structure_id=salary_structure_id,
@@ -976,7 +978,10 @@ def compensations():
     departments = Department.query.order_by(Department.name).all()
     
     def annual_base(comp):
-        return comp.base_salary if comp.salary_type == 'Annual' else comp.base_salary * 2080
+        if comp.salary_type == 'Annual':
+            return comp.base_salary
+        hours = comp.hours_per_week or 40.0
+        return comp.base_salary * hours * 52
 
     def annual_bonus(emp_id):
         return (
@@ -1034,7 +1039,10 @@ def compensation_reports():
         ).all()
 
     def annual_base(comp):
-        return comp.base_salary if comp.salary_type == 'Annual' else comp.base_salary * 2080
+        if comp.salary_type == 'Annual':
+            return comp.base_salary
+        hours = comp.hours_per_week or 40.0
+        return comp.base_salary * hours * 52
 
     def annual_bonus(emp_id):
         return (
@@ -1188,7 +1196,10 @@ def view_compensation_report(report_id):
     results = query.all()
     
     def annual_base(comp):
-        return comp.base_salary if comp.salary_type == 'Annual' else comp.base_salary * 2080
+        if comp.salary_type == 'Annual':
+            return comp.base_salary
+        hours = comp.hours_per_week or 40.0
+        return comp.base_salary * hours * 52
 
     def annual_bonus(emp_id):
         return (

--- a/models/templates/budgeting/projection.html
+++ b/models/templates/budgeting/projection.html
@@ -168,9 +168,9 @@
                         <tr class="fw-bold">
                             <td colspan="3">TOTALS</td>
                             <td>${{ "{:,.2f}".format(total_salary) }}</td>
-                            <td>${{ "{:,.2f}".format(total_benefits * 0.3) }}</td>
+                            <td>${{ "{:,.2f}".format(total_retirement) }}</td>
                             <td>${{ "{:,.2f}".format(total_taxes) }}</td>
-                            <td>${{ "{:,.2f}".format(total_benefits * 0.7) }}</td>
+                            <td>${{ "{:,.2f}".format(total_healthcare) }}</td>
                             <td>${{ "{:,.2f}".format(total_cost) }}</td>
                         </tr>
                     </tfoot>
@@ -200,10 +200,10 @@
                         
                         <div class="d-flex justify-content-between align-items-center">
                             <span>Retirement Contributions</span>
-                            <span>{{ "{:.1f}".format(total_benefits * 0.3 / total_cost * 100) }}%</span>
+                            <span>{{ "{:.1f}".format(total_retirement / total_cost * 100) }}%</span>
                         </div>
                         <div class="progress mb-4">
-                            <div class="progress-bar bg-success" role="progressbar" style="width: {{ total_benefits * 0.3 / total_cost * 100 }}%">
+                            <div class="progress-bar bg-success" role="progressbar" style="width: {{ total_retirement / total_cost * 100 }}%">
                             </div>
                         </div>
                         
@@ -218,10 +218,10 @@
                         
                         <div class="d-flex justify-content-between align-items-center">
                             <span>Health & Other Benefits</span>
-                            <span>{{ "{:.1f}".format(total_benefits * 0.7 / total_cost * 100) }}%</span>
+                            <span>{{ "{:.1f}".format(total_healthcare / total_cost * 100) }}%</span>
                         </div>
                         <div class="progress mb-4">
-                            <div class="progress-bar bg-warning" role="progressbar" style="width: {{ total_benefits * 0.7 / total_cost * 100 }}%">
+                            <div class="progress-bar bg-warning" role="progressbar" style="width: {{ total_healthcare / total_cost * 100 }}%">
                             </div>
                         </div>
                     </div>
@@ -239,11 +239,11 @@
                         <h5><i class="fas fa-info-circle"></i> Projection Details</h5>
                         <p>This projection is based on the following assumptions:</p>
                         <ul>
-                            <li><strong>401(k) Match:</strong> 3% of base salary</li>
+                            <li><strong>401(k) Match:</strong> 4% of base salary (if enrolled)</li>
                             <li><strong>FICA:</strong> 7.65% of salary (6.2% Social Security + 1.45% Medicare)</li>
                             <li><strong>FUTA:</strong> 0.6% on first $7,000 of wages</li>
                             <li><strong>SUTA:</strong> 3.5% of taxable wages (varies by state)</li>
-                            <li><strong>Health Insurance:</strong> Based on current enrollment</li>
+                            <li><strong>Health Insurance:</strong> Placeholder estimate</li>
                             <li><strong>Other Benefits:</strong> Includes life insurance, disability, etc.</li>
                         </ul>
                         <p class="mb-0">

--- a/models/templates/employees/profile.html
+++ b/models/templates/employees/profile.html
@@ -199,6 +199,12 @@
                             ${{ "{:,.2f}".format(employee.base_salary) }}{% if employee.salary_type == 'Hourly' %}/hr{% else %}/yr{% endif %}
                         </p>
                     </div>
+                    {% if employee.salary_type == 'Hourly' %}
+                    <div class="mb-3">
+                        <h6><i class="fas fa-clock mr-2"></i> Hours per Week</h6>
+                        <p>{{ employee.hours_per_week }}</p>
+                    </div>
+                    {% endif %}
                     
                     <!-- Is Manager -->
                     <div class="mb-3">

--- a/models/templates/payroll/create_compensation.html
+++ b/models/templates/payroll/create_compensation.html
@@ -26,6 +26,10 @@
             <input type="number" step="0.01" name="base_salary" class="form-control" required>
         </div>
         <div class="mb-3">
+            <label class="form-label">Hours per Week (if hourly)</label>
+            <input type="number" step="0.1" name="hours_per_week" class="form-control">
+        </div>
+        <div class="mb-3">
             <label class="form-label">Effective Date</label>
             <input type="date" name="effective_date" class="form-control" required>
         </div>

--- a/models/templates/payroll/my_compensation.html
+++ b/models/templates/payroll/my_compensation.html
@@ -38,7 +38,7 @@
                                     <hr>
                                     <div class="d-flex justify-content-between mb-2">
                                         <span>Base Salary</span>
-                                        <span class="fw-bold">${{ "{:,.2f}".format(employee.base_salary if employee.salary_type == 'Annual' else employee.base_salary * 2080) }}</span>
+                                        <span class="fw-bold">${{ "{:,.2f}".format(employee.annual_base_salary) }}</span>
                                     </div>
                                     
                                     {% set total_bonuses = 0 %}
@@ -75,7 +75,7 @@
                                     
                                     <hr>
                                     
-                                    {% set total_compensation = employee.base_salary if employee.salary_type == 'Annual' else employee.base_salary * 2080 %}
+                                    {% set total_compensation = employee.annual_base_salary %}
                                     {% set total_compensation = total_compensation + total_bonuses + total_allowances + total_benefits %}
                                     
                                     <div class="d-flex justify-content-between">
@@ -93,7 +93,7 @@
                                     <h5 class="fw-bold text-primary">Bi-Weekly Pay</h5>
                                     <hr>
                                     
-                                    {% set biweekly_base = employee.base_salary / 26 if employee.salary_type == 'Annual' else employee.base_salary * 80 %}
+                                    {% set biweekly_base = employee.annual_base_salary / 26 %}
                                     
                                     <div class="d-flex justify-content-between mb-2">
                                         <span>Base Pay</span>

--- a/routes/payroll.py
+++ b/routes/payroll.py
@@ -913,6 +913,7 @@ def create_compensation():
         employee_id = request.form.get('employee_id', type=int)
         base_salary = request.form.get('base_salary', type=float)
         salary_type = request.form.get('salary_type') or 'Annual'
+        hours_per_week = request.form.get('hours_per_week', type=float)
         effective_date = request.form.get('effective_date')
         end_date = request.form.get('end_date')
         salary_structure_id = request.form.get('salary_structure_id', type=int)
@@ -926,6 +927,7 @@ def create_compensation():
                 employee_id=employee_id,
                 base_salary=base_salary,
                 salary_type=salary_type,
+                hours_per_week=hours_per_week,
                 effective_date=datetime.strptime(effective_date, '%Y-%m-%d').date(),
                 end_date=datetime.strptime(end_date, '%Y-%m-%d').date() if end_date else None,
                 salary_structure_id=salary_structure_id,
@@ -976,7 +978,10 @@ def compensations():
     departments = Department.query.order_by(Department.name).all()
     
     def annual_base(comp):
-        return comp.base_salary if comp.salary_type == 'Annual' else comp.base_salary * 2080
+        if comp.salary_type == 'Annual':
+            return comp.base_salary
+        hours = comp.hours_per_week or 40.0
+        return comp.base_salary * hours * 52
 
     def annual_bonus(emp_id):
         return (
@@ -1034,7 +1039,10 @@ def compensation_reports():
         ).all()
 
     def annual_base(comp):
-        return comp.base_salary if comp.salary_type == 'Annual' else comp.base_salary * 2080
+        if comp.salary_type == 'Annual':
+            return comp.base_salary
+        hours = comp.hours_per_week or 40.0
+        return comp.base_salary * hours * 52
 
     def annual_bonus(emp_id):
         return (
@@ -1188,7 +1196,10 @@ def view_compensation_report(report_id):
     results = query.all()
     
     def annual_base(comp):
-        return comp.base_salary if comp.salary_type == 'Annual' else comp.base_salary * 2080
+        if comp.salary_type == 'Annual':
+            return comp.base_salary
+        hours = comp.hours_per_week or 40.0
+        return comp.base_salary * hours * 52
 
     def annual_bonus(emp_id):
         return (


### PR DESCRIPTION
## Summary
- add `hours_per_week` to employee compensation
- compute annual salary using hours per week
- update budgeting projection to roll up employee-level calculations
- show hours per week on employee profile
- tweak templates for compensation and budgeting

## Testing
- `pytest -q` *(fails: numpy binary incompatibility)*