### PR TITLE
Add hours_per_week migration

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -49,10 +49,11 @@ pip install -r dependencies.txt
 Note: The dependencies.txt file contains all the required Python packages for this application.
 
 #### Initialize the Database Schema
-Apply the initial Alembic migration to create all tables:
+Apply the Alembic migrations to create or update all tables:
 ```bash
 alembic upgrade head
 ```
+Run this command whenever you pull new updates to apply the latest database migrations.
 
 ### 4. Application Configuration
 

--- a/alembic/versions/0002_add_hours_per_week.py
+++ b/alembic/versions/0002_add_hours_per_week.py
@@ -1,0 +1,18 @@
+"""Add hours_per_week column to employee_compensations"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0002'
+down_revision = '0001'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('employee_compensations', sa.Column('hours_per_week', sa.Float(), nullable=True, server_default='40'))
+    op.alter_column('employee_compensations', 'hours_per_week', server_default=None)
+
+
+def downgrade():
+    op.drop_column('employee_compensations', 'hours_per_week')


### PR DESCRIPTION
## Summary
- add migration to include `hours_per_week` in `employee_compensations`
- document running alembic upgrades after pulling updates

## Testing
- `pytest -q` *(fails: ImportError pandas binary incompatibility)*