### PR TITLE
Switch to SECRET_KEY env variable

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 DATABASE_URL=mssql+pyodbc://sa:YOUR_SQL_PASSWORD@localhost:1433/employee_management?driver=ODBC+Driver+17+for+SQL+Server
-SESSION_SECRET=replace_with_secure_random_value
+SECRET_KEY=replace_with_secure_random_value
 MSSQL_HOST=localhost
 MSSQL_PORT=1433
 MSSQL_DATABASE=employee_management

--- a/README.txt
+++ b/README.txt
@@ -61,7 +61,7 @@ Run this command whenever you pull new updates to apply the latest database migr
 Create a file named `.env` in the root directory:
 ```
 DATABASE_URL=mssql+pyodbc://sa:secure_password@localhost:1433/employee_management?driver=ODBC+Driver+17+for+SQL+Server
-SESSION_SECRET=your_secure_secret_key
+SECRET_KEY=your_secure_secret_key
 MSSQL_HOST=localhost
 MSSQL_PORT=1433
 MSSQL_DATABASE=employee_management
@@ -69,7 +69,7 @@ MSSQL_USER=sa
 MSSQL_PASSWORD=secure_password
 ```
 
-Replace `secure_password` with your actual SQL Server password and generate a random value for `SESSION_SECRET`.
+Replace `secure_password` with your actual SQL Server password and generate a random value for `SECRET_KEY`.
 
 On the first run the application will automatically create all database tables
 and seed initial data such as roles, a default admin account, document types and

--- a/models/app/__init__.py
+++ b/models/app/__init__.py
@@ -20,7 +20,7 @@ load_dotenv()
 def create_app(config_object=None):
     """Application factory."""
     app = Flask(__name__)
-    app.secret_key = os.environ.get("SESSION_SECRET")
+    app.secret_key = os.environ.get("SECRET_KEY")
     app.wsgi_app = ProxyFix(app.wsgi_app, x_proto=1, x_host=1)
 
     # Load configuration

--- a/models/tests/conftest.py
+++ b/models/tests/conftest.py
@@ -7,7 +7,7 @@ from models import Role, User
 @pytest.fixture()
 def app():
     os.environ.setdefault('DATABASE_URL', 'sqlite:///:memory:')
-    os.environ.setdefault('SESSION_SECRET', 'testing')
+    os.environ.setdefault('SECRET_KEY', 'testing')
     app = create_app({
         'TESTING': True,
         'SQLALCHEMY_DATABASE_URI': 'sqlite:///:memory:',

--- a/models/tests/test_auth_login.py
+++ b/models/tests/test_auth_login.py
@@ -4,7 +4,7 @@ from flask import url_for
 
 # Configure in-memory SQLite before importing app
 os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
-os.environ['SESSION_SECRET'] = 'testing'
+os.environ['SECRET_KEY'] = 'testing'
 
 from app import create_app, db
 from models import User

--- a/models/tests/test_budget_views.py
+++ b/models/tests/test_budget_views.py
@@ -4,7 +4,7 @@ import pytest
 
 # Configure database before importing app
 os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
-os.environ['SESSION_SECRET'] = 'testing'
+os.environ['SECRET_KEY'] = 'testing'
 
 from app import create_app, db
 from models import Role, User, Department, Budget

--- a/models/tests/test_create_compensation.py
+++ b/models/tests/test_create_compensation.py
@@ -3,7 +3,7 @@ import datetime
 import pytest
 
 os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
-os.environ['SESSION_SECRET'] = 'testing'
+os.environ['SECRET_KEY'] = 'testing'
 
 import app
 from app import db

--- a/models/tests/test_create_employee_account.py
+++ b/models/tests/test_create_employee_account.py
@@ -4,7 +4,7 @@ import pytest
 
 # Configure in-memory SQLite before importing app
 os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
-os.environ['SESSION_SECRET'] = 'testing'
+os.environ['SECRET_KEY'] = 'testing'
 
 from app import create_app, db
 from models import Role, User, Employee

--- a/models/tests/test_download_payslip.py
+++ b/models/tests/test_download_payslip.py
@@ -4,7 +4,7 @@ from unittest import mock
 import pytest
 
 os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
-os.environ['SESSION_SECRET'] = 'testing'
+os.environ['SECRET_KEY'] = 'testing'
 
 from app import create_app, db
 from models import Role, User, Employee, PayPeriod, Payroll, PayrollEntry

--- a/models/tests/test_edit_payslip.py
+++ b/models/tests/test_edit_payslip.py
@@ -3,7 +3,7 @@ import datetime
 import pytest
 
 os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
-os.environ['SESSION_SECRET'] = 'testing'
+os.environ['SECRET_KEY'] = 'testing'
 
 from app import create_app, db
 from models import Role, User, Employee, EmployeeCompensation, PayPeriod, Payroll, PayrollEntry

--- a/models/tests/test_generate_report_pdf.py
+++ b/models/tests/test_generate_report_pdf.py
@@ -4,7 +4,7 @@ import sqlalchemy
 import pytest
 
 os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
-os.environ['SESSION_SECRET'] = 'testing'
+os.environ['SECRET_KEY'] = 'testing'
 
 from app import create_app, db
 from models import Role, User, Employee, CompensationReport

--- a/models/tests/test_payroll_periods.py
+++ b/models/tests/test_payroll_periods.py
@@ -3,7 +3,7 @@ import sqlalchemy
 import pytest
 from datetime import date, timedelta
 
-os.environ['SESSION_SECRET'] = 'testing'
+os.environ['SECRET_KEY'] = 'testing'
 
 from app import create_app, db
 from seed_data import create_seed_data

--- a/models/tests/test_payroll_processing.py
+++ b/models/tests/test_payroll_processing.py
@@ -4,7 +4,7 @@ import pytest
 
 # Configure app to use in-memory SQLite before importing
 os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
-os.environ['SESSION_SECRET'] = 'testing'
+os.environ['SECRET_KEY'] = 'testing'
 
 from app import create_app, db
 from models import Role, User, Employee, EmployeeCompensation, PayPeriod, Payroll, PayrollEntry

--- a/models/tests/test_role_management.py
+++ b/models/tests/test_role_management.py
@@ -4,7 +4,7 @@ import pytest
 
 # Configure in-memory database before importing the app
 os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
-os.environ['SESSION_SECRET'] = 'testing'
+os.environ['SECRET_KEY'] = 'testing'
 
 from app import create_app, db
 from models import Role, Permission, User

--- a/models/tests/test_timesheet_service.py
+++ b/models/tests/test_timesheet_service.py
@@ -4,7 +4,7 @@ import sqlalchemy
 import pytest
 
 os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
-os.environ['SESSION_SECRET'] = 'testing'
+os.environ['SECRET_KEY'] = 'testing'
 
 import app
 from app import db

--- a/models/tests/test_user_model.py
+++ b/models/tests/test_user_model.py
@@ -2,7 +2,7 @@ import os
 
 # Configure in-memory test environment
 os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
-os.environ['SESSION_SECRET'] = 'testing'
+os.environ['SECRET_KEY'] = 'testing'
 
 from models import User
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from models import Role, User
 @pytest.fixture()
 def app():
     os.environ.setdefault('DATABASE_URL', 'sqlite:///:memory:')
-    os.environ.setdefault('SESSION_SECRET', 'testing')
+    os.environ.setdefault('SECRET_KEY', 'testing')
     app = create_app({
         'TESTING': True,
         'SQLALCHEMY_DATABASE_URI': 'sqlite:///:memory:',

--- a/tests/test_auth_login.py
+++ b/tests/test_auth_login.py
@@ -4,7 +4,7 @@ from flask import url_for
 
 # Configure in-memory SQLite before importing app
 os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
-os.environ['SESSION_SECRET'] = 'testing'
+os.environ['SECRET_KEY'] = 'testing'
 
 from app import create_app, db
 from models import User

--- a/tests/test_budget_views.py
+++ b/tests/test_budget_views.py
@@ -4,7 +4,7 @@ import pytest
 
 # Configure database before importing app
 os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
-os.environ['SESSION_SECRET'] = 'testing'
+os.environ['SECRET_KEY'] = 'testing'
 
 from app import create_app, db
 from models import Role, User, Department, Budget

--- a/tests/test_create_compensation.py
+++ b/tests/test_create_compensation.py
@@ -3,7 +3,7 @@ import datetime
 import pytest
 
 os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
-os.environ['SESSION_SECRET'] = 'testing'
+os.environ['SECRET_KEY'] = 'testing'
 
 import app
 from app import db

--- a/tests/test_create_employee_account.py
+++ b/tests/test_create_employee_account.py
@@ -4,7 +4,7 @@ import pytest
 
 # Configure in-memory SQLite before importing app
 os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
-os.environ['SESSION_SECRET'] = 'testing'
+os.environ['SECRET_KEY'] = 'testing'
 
 from app import create_app, db
 from models import Role, User, Employee

--- a/tests/test_download_payslip.py
+++ b/tests/test_download_payslip.py
@@ -4,7 +4,7 @@ from unittest import mock
 import pytest
 
 os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
-os.environ['SESSION_SECRET'] = 'testing'
+os.environ['SECRET_KEY'] = 'testing'
 
 from app import create_app, db
 from models import Role, User, Employee, PayPeriod, Payroll, PayrollEntry

--- a/tests/test_edit_payslip.py
+++ b/tests/test_edit_payslip.py
@@ -3,7 +3,7 @@ import datetime
 import pytest
 
 os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
-os.environ['SESSION_SECRET'] = 'testing'
+os.environ['SECRET_KEY'] = 'testing'
 
 from app import create_app, db
 from models import Role, User, Employee, EmployeeCompensation, PayPeriod, Payroll, PayrollEntry

--- a/tests/test_generate_report_pdf.py
+++ b/tests/test_generate_report_pdf.py
@@ -4,7 +4,7 @@ import sqlalchemy
 import pytest
 
 os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
-os.environ['SESSION_SECRET'] = 'testing'
+os.environ['SECRET_KEY'] = 'testing'
 
 from app import create_app, db
 from models import Role, User, Employee, CompensationReport

--- a/tests/test_payroll_periods.py
+++ b/tests/test_payroll_periods.py
@@ -3,7 +3,7 @@ import sqlalchemy
 import pytest
 from datetime import date, timedelta
 
-os.environ['SESSION_SECRET'] = 'testing'
+os.environ['SECRET_KEY'] = 'testing'
 
 from app import create_app, db
 from seed_data import create_seed_data

--- a/tests/test_payroll_processing.py
+++ b/tests/test_payroll_processing.py
@@ -4,7 +4,7 @@ import pytest
 
 # Configure app to use in-memory SQLite before importing
 os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
-os.environ['SESSION_SECRET'] = 'testing'
+os.environ['SECRET_KEY'] = 'testing'
 
 from app import create_app, db
 from models import Role, User, Employee, EmployeeCompensation, PayPeriod, Payroll, PayrollEntry

--- a/tests/test_role_management.py
+++ b/tests/test_role_management.py
@@ -4,7 +4,7 @@ import pytest
 
 # Configure in-memory database before importing the app
 os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
-os.environ['SESSION_SECRET'] = 'testing'
+os.environ['SECRET_KEY'] = 'testing'
 
 from app import create_app, db
 from models import Role, Permission, User

--- a/tests/test_timesheet_service.py
+++ b/tests/test_timesheet_service.py
@@ -4,7 +4,7 @@ import sqlalchemy
 import pytest
 
 os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
-os.environ['SESSION_SECRET'] = 'testing'
+os.environ['SECRET_KEY'] = 'testing'
 
 import app
 from app import db

--- a/tests/test_user_model.py
+++ b/tests/test_user_model.py
@@ -2,7 +2,7 @@ import os
 
 # Configure in-memory test environment
 os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
-os.environ['SESSION_SECRET'] = 'testing'
+os.environ['SECRET_KEY'] = 'testing'
 
 from models import User
 


### PR DESCRIPTION
## Summary
- update env example and docs to use `SECRET_KEY`
- update create_app references in models
- set `SECRET_KEY` when loading tests instead of `SESSION_SECRET`

## Testing
- `pytest -q` *(fails: numpy dtype size changed)*