### PR TITLE
Add attendance date range test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,21 @@
 import os
+import sys
+import types
 import pytest
-from app import create_app, db
 import sqlalchemy
+
+# Provide a lightweight pandas stub so create_app imports succeed even when
+# the real pandas dependency is unavailable in the execution environment.
+sys.modules.setdefault(
+    "pandas",
+    types.SimpleNamespace(read_csv=lambda *a, **k: None, read_excel=lambda *a, **k: None),
+)
+
+# Ensure a default in-memory database is used when the app module is imported.
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("SESSION_SECRET", "testing")
+
+from app import create_app, db
 from models import Role, User
 
 @pytest.fixture()

--- a/tests/test_attendance_date_range.py
+++ b/tests/test_attendance_date_range.py
@@ -1,0 +1,13 @@
+from datetime import datetime, date
+from types import SimpleNamespace
+
+from routes import attendance
+
+
+def test_get_default_date_range(monkeypatch):
+    mock_dt = SimpleNamespace(now=lambda tz=None: datetime(2024, 5, 15))
+    monkeypatch.setattr(attendance, "datetime", mock_dt)
+
+    start, end = attendance.get_default_date_range()
+    assert start == date(2024, 5, 1)
+    assert end == date(2024, 5, 31)


### PR DESCRIPTION
## Summary
- stub pandas import in `conftest.py` and set default env vars before importing app
- add a unit test for `routes.attendance.get_default_date_range` that monkeypatches `datetime`

## Testing
- `pytest -q tests/test_attendance_date_range.py`
- `pytest -q` *(fails: 12 failed, 49 passed, 32 errors)*